### PR TITLE
hyphen instead of underscore in .deb name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(cpp_arg_parser)
+project(cpp-arg-parser)
 include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
https://kerneltalks.com/tools/understanding-package-naming-convention-rpm-deb/